### PR TITLE
Add top position with props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,12 @@ interface Props {
      * @type {boolean}
      */
     shadow?: boolean;
+    /**
+     * Set top position of progress bar
+     * Default value is 0px
+     * @type {boolean}
+     */
+    top?: string;
 }
 
 export default class Snakke extends Component<Props> {}

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default class Snakke extends Component {
 
   styles = {
     position: 'fixed',
-    top: '0',
+    top: this.props.top,
     left: '0',
     width: '100%',
     height: this.props.height,
@@ -56,5 +56,6 @@ Snakke.defaultProps = {
   height: '5px',
   opacity: '1',
   zIndex: '9999',
-  shadow: false
+  shadow: false,
+  top: '0px',
 }

--- a/src/index.js
+++ b/src/index.js
@@ -57,5 +57,5 @@ Snakke.defaultProps = {
   opacity: '1',
   zIndex: '9999',
   shadow: false,
-  top: '0px',
+  top: '0',
 }


### PR DESCRIPTION
Consider adding a property to the top value, for the header case set at the top.

It was very interesting. see on my website:

https://nandomoreira.dev/blog/customizando-a-mensagem-noscript-no-gatsby

![image](https://user-images.githubusercontent.com/1318271/54647041-dd8fc680-4a7f-11e9-8e87-f478e78b769f.png)
